### PR TITLE
Add ability to play custom sounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "react-geiger",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-geiger",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "ISC",
-      "dependencies": {
-        "@tsconfig/vite-react": "^3.0.1"
-      },
       "devDependencies": {
         "@kristiandupont/dev-deps": "^2.24.0",
         "@kristiandupont/dev-deps-react": "^1.7.0",
@@ -1465,11 +1462,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.3.tgz",
       "integrity": "sha512-+jby/Guq9H8O7NWgCv6X8VAiQE8Dr/nccsCtL74xyHKhu2Knu5EAKmOZj3nLCnLm1KooUzKY+5DsnGVqhM8/wQ==",
       "dev": true
-    },
-    "node_modules/@tsconfig/vite-react": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/vite-react/-/vite-react-3.0.1.tgz",
-      "integrity": "sha512-yrAEQWgWZdbfNt/11TrvUPkh0AJrJy+DP9qc4c5zPt8POGwYfEp8dB2LnBC9DBm/zpycsasRJh8Z9uVB17yxCw=="
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",

--- a/src/Geiger.tsx
+++ b/src/Geiger.tsx
@@ -8,6 +8,22 @@ import {
   useState,
 } from "react";
 
+function playGeigerSoundFile(
+  audioContext: AudioContext,
+  src: string,
+  amplitude: number
+) {
+  const audioElement = new Audio(src);
+  const audioSource = audioContext.createMediaElementSource(audioElement);
+  audioSource.connect(audioContext.destination);
+  audioElement.volume = amplitude;
+  //  Limit audio to 1s
+  audioElement.play();
+  setTimeout(() => {
+    audioElement.pause();
+    audioElement.currentTime = 0;
+  }, 1000);
+}
 function playGeigerClickSound(audioContext: AudioContext, amplitude: number) {
   const volume = Math.max(0.5, amplitude);
   const duration = 0.001;
@@ -56,6 +72,7 @@ const Geiger: FC<{
   renderTimeThreshold?: number;
   phaseOption?: PhaseOption;
   enabled?: boolean;
+  customSound?: string;
   children: ReactNode;
 }> = ({
   profilerId = "geiger",
@@ -63,6 +80,7 @@ const Geiger: FC<{
   phaseOption = "both",
   enabled = true,
   children,
+  customSound,
 }) => {
   const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
 
@@ -77,7 +95,13 @@ const Geiger: FC<{
           1,
           (actualDuration - renderTimeThreshold) / (renderTimeThreshold * 2)
         );
-        playGeigerClickSound(audioContext, amplitude);
+
+        if (customSound && typeof customSound == "string") {
+          if (customSound === "") {
+            console.warn("The sound file path is empty");
+          }
+          playGeigerSoundFile(audioContext, customSound, amplitude);
+        } else playGeigerClickSound(audioContext, amplitude);
       }
     },
     [audioContext, phaseOption, renderTimeThreshold]


### PR DESCRIPTION
Added a `customSounds` option. One can pass a valid source to the sound file they want to play and have it play on the re renders instead of the click sound.  Tested in CRA.

## Example usage
```tsx

import React from 'react';
import ReactDOM from 'react-dom/client';
import App from './App';
import { Geiger } from 'react-geiger';
import sound from './assets/sound.mp3'

const root = ReactDOM.createRoot(document.getElementById('root'));
root.render(
  <React.StrictMode>
    <Geiger customSound={fard} renderTimeThreshold={0}>
      <App />
    </Geiger>
  </React.StrictMode>
);
```